### PR TITLE
ASoC: tpa6165a2: Lower the headphones amplifier gain

### DIFF
--- a/sound/soc/codecs/tpa6165a2.c
+++ b/sound/soc/codecs/tpa6165a2.c
@@ -112,7 +112,7 @@ static const struct tpa6165_regs tpa6165_reg_defaults[] = {
 },
 {
 	.reg = TPA6165_HPH_VOL_CTL_REG1,
-	.value = 0xb9,
+	.value = 0xb3,
 },
 {
 	.reg = TPA6165_HPH_VOL_CTL_REG2,


### PR DESCRIPTION
Lower the volume level from 0dB to -6dB. This will minimize the
static noise that can be heard with low impendance headphones
without decreasing the maximum volume level in a noticeable way.

Change-Id: I2087dba460bba914a303a3beccc632769b18dd0a
